### PR TITLE
Adds start and end character positions to tag structure - available to tag transformers

### DIFF
--- a/Sources/NSScanner+Swift.swift
+++ b/Sources/NSScanner+Swift.swift
@@ -44,4 +44,22 @@ extension Scanner {
         }
         return nil
     }
+    
+    /// The character `String.Index` at which the receiver will begin its next scanning operation.
+    var currentCharacterIndex: String.Index {
+        let utf16View = string.utf16
+        
+        guard let scanLocationInUTF16 = utf16View.index(
+            utf16View.startIndex,
+            offsetBy: scanLocation,
+            limitedBy: utf16View.endIndex
+        ), let scanLoactionForCharacter = String.Index(
+            scanLocationInUTF16,
+            within: string
+        ) else {
+            return string.endIndex
+        }
+        
+        return scanLoactionForCharacter
+    }
 }

--- a/Sources/String+Detection.swift
+++ b/Sources/String+Detection.swift
@@ -8,6 +8,8 @@ import Foundation
 public struct Tag {
     public let name: String
     public let attributes: [String: String]
+    public let startPosition: String.Index
+    public let endPosition: String.Index
 }
 
 public struct TagInfo {
@@ -46,7 +48,7 @@ public struct TagTransformer {
 
 extension String {
     
-    private func parseTag(_ tagString: String, parseAttributes: Bool) -> Tag? {
+    private func parseTag(_ tagString: String, parseAttributes: Bool, tagStartPosition: String.Index, tagEndPosition: String.Index) -> Tag? {
         let tagScanner = Scanner(string: tagString)
         
         guard let tagName = tagScanner.scanCharacters(from: CharacterSet.alphanumerics) else {
@@ -83,7 +85,7 @@ extension String {
             attributes[name] = value.replacingOccurrences(of: "&quot;", with: "\"")
         }
         
-        return Tag(name: tagName, attributes: attributes)
+        return Tag(name: tagName, attributes: attributes, startPosition: tagStartPosition, endPosition: tagEndPosition)
     }
     
     public func detectTags(transformers: [TagTransformer] = []) -> (string: String, tagsInfo: [TagInfo]) {
@@ -106,6 +108,7 @@ extension String {
             if let textString = scanner.scanUpToCharacters(from: CharacterSet(charactersIn: "<&")) {
                 resultString.append(textString)
             } else {
+                let tagStartPosition = scanner.currentCharacterIndex
                 if scanner.scanString("<") != nil {
                     
                     if scanner.isAtEnd {
@@ -118,7 +121,8 @@ extension String {
                             if let tagString = scanner.scanUpTo(">") {
                                 
                                 if scanner.scanString(">") != nil {
-                                    if let tag = parseTag(tagString, parseAttributes: tagType == .start ) {
+                                    let tagEndPosition = scanner.currentCharacterIndex
+                                    if let tag = parseTag(tagString, parseAttributes: tagType == .start, tagStartPosition: tagStartPosition, tagEndPosition: tagEndPosition) {
                                         
                                         let resultTextEndIndex = resultString.count
                                         

--- a/Tests/AtributikaTests/AtributikaTests.swift
+++ b/Tests/AtributikaTests/AtributikaTests.swift
@@ -457,6 +457,77 @@ class AtributikaTests: XCTestCase {
         XCTAssertEqual(tags[0].tag.attributes["href"], "http://foo.com")
     }
     
+    func testTagStartEndPositions() throws {
+        let test = "Hello 👸🏽 <a class=\"big\" target=\"\" href=\"http://foo.com\"><strong>world 👍🏼</strong></a>!"
+        
+        var linkOpeningTagStartPosition: String.Index?
+        var linkOpeningTagEndPosition: String.Index?
+        var linkClosingTagStartPosition: String.Index?
+        var linkClosingTagEndPosition: String.Index?
+        
+        var strongOpeningTagStartPosition: String.Index?
+        var strongOpeningTagEndPosition: String.Index?
+        var strongClosingTagStartPosition: String.Index?
+        var strongClosingTagEndPosition: String.Index?
+        
+        let transformers: [TagTransformer] = [
+            TagTransformer(tagName: "a", tagType: .start) { tag in
+                linkOpeningTagStartPosition = tag.startPosition
+                linkOpeningTagEndPosition = tag.endPosition
+                return ""
+            },
+            TagTransformer(tagName: "a", tagType: .end) { tag in
+                linkClosingTagStartPosition = tag.startPosition
+                linkClosingTagEndPosition = tag.endPosition
+                return ""
+            },
+            TagTransformer(tagName: "strong", tagType: .start) { tag in
+                strongOpeningTagStartPosition = tag.startPosition
+                strongOpeningTagEndPosition = tag.endPosition
+                return ""
+            },
+            TagTransformer(tagName: "strong", tagType: .end) { tag in
+                strongClosingTagStartPosition = tag.startPosition
+                strongClosingTagEndPosition = tag.endPosition
+                return ""
+            }
+        ]
+        
+        let result = test.style(tags: [], transformers: transformers)
+        
+        XCTAssertEqual(result.string, "Hello 👸🏽 world 👍🏼!")
+        
+        XCTAssertEqual(
+            test[try XCTUnwrap(linkOpeningTagStartPosition)..<XCTUnwrap(linkOpeningTagEndPosition)],
+            "<a class=\"big\" target=\"\" href=\"http://foo.com\">"
+        )
+        
+        XCTAssertEqual(
+            test[try XCTUnwrap(linkClosingTagStartPosition)..<XCTUnwrap(linkClosingTagEndPosition)],
+            "</a>"
+        )
+        
+        XCTAssertEqual(
+            test[try XCTUnwrap(linkOpeningTagStartPosition)..<XCTUnwrap(linkClosingTagEndPosition)],
+            "<a class=\"big\" target=\"\" href=\"http://foo.com\"><strong>world 👍🏼</strong></a>"
+        )
+        
+        XCTAssertEqual(
+            test[try XCTUnwrap(strongOpeningTagStartPosition)..<XCTUnwrap(strongOpeningTagEndPosition)],
+            "<strong>"
+        )
+        
+        XCTAssertEqual(
+            test[try XCTUnwrap(strongClosingTagStartPosition)..<XCTUnwrap(strongClosingTagEndPosition)],
+            "</strong>"
+        )
+        
+        XCTAssertEqual(
+            test[try XCTUnwrap(strongOpeningTagStartPosition)..<XCTUnwrap(strongClosingTagEndPosition)],
+            "<strong>world 👍🏼</strong>"
+        )
+    }
+    
     func testTagAttributesWithSingleQuote() {
         let test = "Hello <a class='big' target='' href=\"http://foo.com\">world</a>!"
         


### PR DESCRIPTION
This change introduces tag character positions relative to the original string as part of the `Tag` structure. These can then be used by `TagTransformer` transformation functions.

It may not be immediately obvious why this change may be useful, but I have found it to be quite useful for extracting content that wouldn't be suitable for attributed string transformation from within content that _is_ suitable for attributed string transformation. 

For example, if the html being transformed is mostly transformable content, but contains an `iframe` tag, or a Twitter `blockquote` somewhere within it, the positions of these tags (opening and/or closing) have been useful in order to split, extract, and treat them accordingly.

I've used emojis with variations to include grapheme clusters in the unit test to ensure the `String.Index` values handle these correctly _(via UTF16)_. 